### PR TITLE
Deprecating `mujoco_py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 data/
 __pycache__/
 .ipynb_checkpoints/
+.vscode/settings.json

--- a/configs/rl_experiment/cartpole/mpd.yaml
+++ b/configs/rl_experiment/cartpole/mpd.yaml
@@ -12,10 +12,10 @@ mlp:
         shift:
         scale: 500
 
-trials: 3
+trials: 1
 # Either choose max_iterations or max_objective_calls unequal None.
 max_iterations:
-max_objective_calls: 100
+max_objective_calls: 20
 
 optimizer_config:
     max_samples_per_iteration: 8

--- a/configs/rl_experiment/hopper/mpd.yaml
+++ b/configs/rl_experiment/hopper/mpd.yaml
@@ -1,8 +1,8 @@
 method: mpd
 
-out_dir: './experiments/rl_experiments/hopper/gibo/'  # Directory for experiment results.
+out_dir: './experiments/rl_experiments/hopper/mpd/'  # Directory for experiment results.
 
-environment_name: Hopper-v1
+environment_name: Hopper-v4
 mlp:
     layers: [11,3]
     discretize:
@@ -12,10 +12,10 @@ mlp:
         shift: 1
         scale: 1000
 
-trials: 3
+trials: 1
 # Either choose max_iterations or max_objective_calls unequal None.
 max_iterations:
-max_objective_calls: 8000
+max_objective_calls: 35
 
 optimizer_config:
     max_samples_per_iteration: 32

--- a/configs/rl_experiment/mpd_default.yaml
+++ b/configs/rl_experiment/mpd_default.yaml
@@ -2,7 +2,7 @@ method: mpd
 
 out_dir: './experiments/rl_experiments/test_experiment/gibo/'  # Directory for experiment results.
 
-environment_name: Swimmer-v1
+environment_name: Swimmer-v4
 mlp:
     layers: [8,2]
     discretize:

--- a/configs/rl_experiment/swimmer/mpd.yaml
+++ b/configs/rl_experiment/swimmer/mpd.yaml
@@ -2,7 +2,7 @@ method: mpd
 
 out_dir: './experiments/rl_experiments/swimmer/gibo/'  # Directory for experiment results.
 
-environment_name: Swimmer-v1
+environment_name: Swimmer-v4
 mlp:
     layers: [8,2]
     discretize:
@@ -12,10 +12,10 @@ mlp:
         shift:
         scale: 350
 
-trials: 3
+trials: 1
 # Either choose max_iterations or max_objective_calls unequal None.
 max_iterations:
-max_objective_calls: 2000
+max_objective_calls: 30
 
 optimizer_config:
     max_samples_per_iteration: 16

--- a/environment.yaml
+++ b/environment.yaml
@@ -16,5 +16,6 @@ dependencies:
     - torch==1.11.0
     - torchvision==0.7.0
     - glfw==1.12.0
+    - mujoco==2.1.2
     - gymnasium==0.26.1
     - imageio==2.34.2

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,8 +13,6 @@ dependencies:
   - pip:
     - botorch==0.6.3.1
     - gpytorch==1.6.0
-    - gym==0.9.3
-    - mujoco-py==2.1.2.14
     - torch==1.11.0
     - torchvision==0.7.0
     - glfw==1.12.0

--- a/environment.yaml
+++ b/environment.yaml
@@ -16,3 +16,5 @@ dependencies:
     - torch==1.11.0
     - torchvision==0.7.0
     - glfw==1.12.0
+    - gymnasium==0.26.1
+    - imageio==2.34.2

--- a/src/environment_api.py
+++ b/src/environment_api.py
@@ -6,8 +6,8 @@ from time import time
 import glfw
 
 import torch
-import gym
-from gym import wrappers
+import gymnasium as gym
+from gymnasium import wrappers
 
 
 class EnvironmentObjective:
@@ -114,10 +114,14 @@ class EnvironmentObjective:
         """
         states, actions, rewards = self._unpack_episode()
         r = 0
-        states[0] = self.manipulate_state(self.env.reset())
+        obs, info = self.env.reset()
+        print(f"State: {obs}")
+        # print(obs)
+        # print(info)
+        states[0] = self.manipulate_state(obs)
         for t in range(self.max_steps):  # rollout
             actions[t] = self.policy(states[t], params)
-            state, rewards[t], done, _ = self.env.step(actions[t].numpy())
+            state, rewards[t], done, trunc, _ = self.env.step(actions[t].numpy())
             states[t + 1] = self.manipulate_state(state)
             r += self.manipulate_reward(
                 rewards[t], actions[t], states[t + 1], done

--- a/src/optimizers.py
+++ b/src/optimizers.py
@@ -1023,6 +1023,7 @@ class MPDOptimizer(AbstractOptimizer):
 
         # Sample with new params from objective and add this to train data.
         # Optionally forget old points (if N > N_max).
+        print(f"Start of step.")
         self.old_f_params = self.f_params
         self.old_f_reward = self.f_reward
         f_params = self.objective(self.params)
@@ -1075,6 +1076,7 @@ class MPDOptimizer(AbstractOptimizer):
 
         for i in range(self.max_samples_per_iteration):
             # Optimize acquistion function and get new observation.
+            print("Acquiring points for gradient")
             new_x, acq_value = self.optimize_acqf(self.acquisition_fcn, self.bounds)
             new_y = self.objective(new_x)
 
@@ -1088,6 +1090,7 @@ class MPDOptimizer(AbstractOptimizer):
                     self.params.detach()
                 )
                 self.p_star = uphill_probability.item()
+                print(f"Uphill prob: {self.p_star}")
 
             if self.wandb_run is not None:
                 self.log_stats(log_rewards=False)


### PR DESCRIPTION
Plan:

- [x] Upgrade all mujoco envs used to `v4`:
> For MuJoCo V3 environments and older the mujoco-py framework is required (pip install mujoco-py) which can be found in the [GitHub repository](https://github.com/openai/mujoco-py/tree/master/mujoco_py) 
- [x] Replace `gym` with `gymnasium`
  - [x] Determine version of `gymnasium` with least API changes from `gym` but still support `v4` 
  - [x] Change `mpd` code to reflect differences
- [x] Determine version of `mujoco` to download
  - [x] The first version of mujoco appears to be [v2.1.2](https://mujoco.readthedocs.io/en/2.1.2/python.html)
- [x] Make any necessary API changes on `mpd` side
  - [x] `EnvironmentObjective` is probably the main file
- [x] Update final env file